### PR TITLE
Patch 4.3

### DIFF
--- a/_posts/01-16-2021-Patch-4.3.md
+++ b/_posts/01-16-2021-Patch-4.3.md
@@ -1,0 +1,7 @@
+- Blacklisted blocks has been added!
+- - Use `/blocklist add` to add blocks/items to your blocklist!
+- - Use `/blocklist` without any arguments to show all blacklisted items
+- - Only nine can be displayed at a time, however any number can be blacklisted
+- Inventory loading functions will now prioritize saved inventories over inherited ones.
+- - A GUI menu will pop up to offer inventory options upon becoming a Hero
+- Fixes made to the `/find` command's GUI


### PR DESCRIPTION
- Blacklisted blocks has been added!
- - Use `/blocklist add` to add blocks/items to your blocklist!
- - Use `/blocklist` without any arguments to show all blacklisted items
- - Only nine can be displayed at a time, however any number can be blacklisted
- Inventory loading functions will now prioritize saved inventories over inherited ones.
- - A GUI menu will pop up to offer inventory options upon becoming a Hero
- Fixes made to the `/find` command's GUI