### PR TITLE
Patch 4.6-7

### DIFF
--- a/_posts/2021-01-18-Patch-4.6-7.md
+++ b/_posts/2021-01-18-Patch-4.6-7.md
@@ -1,0 +1,7 @@
+### Patch 4.6-7
+- Hero shop located at spawn has been updated and all items should be working properly
+- Bone, Poison, Ghoul, and Feathershrimp charms have been updated and must be equip to the offhand slot
+- Several premium weapon abilities have been updated including but not limited to:
+- - Powerul weapons forged in the nether that strike lightning at opponents
+- - Powerul weapons that take out your foes using explosions from afar
+- - Much more

--- a/_posts/Home.md
+++ b/_posts/Home.md
@@ -7,74 +7,69 @@ layout: wikiPage
 {% include_relative _Sidebar.md %}
 
 * * *
+
 ### How to Play _(Minecraft 1.16.4 Java Edition)_
 
-This server features a custom game mode similar to manhunt where players must clear out dungeons while fighting monsters controlled by other players. Each dungeon has progressive levels with custom loot and bosses.
+This server features a custom game mode similar to manhunt where players (_**Heroes**_) must clear out dungeons while fighting monsters controlled by other players (_**Ghosts**_). Each dungeon has progressive levels with custom loot and bosses.
 
-Players must play as either a Hero or Ghost. Ghosts play in spectator mode with the ability to control mobs/monsters. Ghosts must kill a Hero, in order to become a Hero. Ghosts can unlock artifacts as well as spawn and upgrade monsters using experience levels.
+Players must play as either a _**Hero**_ or _**Ghost**_. _**Ghosts**_ play in spectator mode with the ability to control mobs/monsters. _Ghosts_ must kill a Hero, in order to become a Hero. _Ghosts_ can unlock artifacts as well as spawn and upgrade monsters using experience levels.
 
-Heroes play in survival mode and must defeat dungeon levels in order to win. Heroes are able to purchase custom kits, items and enchantments using experience levels. Heroes are also able to craft custom spells. Learn more at the server wiki page.
+_**Heroes**_ play in survival mode and must defeat dungeon levels in order to win. _Heroes_ are able to purchase custom kits, items and enchantments using experience levels. Heroes are also able to craft custom spells. Learn more at the server wiki page.
 
 * * *
-![](https://www.crawl-survival.com/assets/Up+to+10+Heroes.png)
 
-If a player dies(or disconnects) as a Hero, they will become a Ghost, and their Hero slot (and inventory) is given to another player.
+### Gamemode Commands
 
-Heroes must make it to The End to slay the Ender Dragon. The player to retrieve the Egg will be rewarded champion
+- `/ghost` Respawn as a Ghost in spectator mode.
+- `/help` Opens up the Mine-Crawl in game GUI help menu
+- `/hero` Respawn as a Hero at spawn (or bed) in survival mode.
+- `/premium` Opens up in game premium GUI menu
+
+### Teleportation Commands
+
+- `/spawn` Teleports the player to spawn. Heroes have a cooldown.
+- `/find` Teleport to Heroes. Heroes can teleport to other Heroes but it will cost an ender pearl.
 
 ### Hero Commands
-
-*   **_/chest_** Opens up the player's ender chest. Costs one ender pearl for Heroes.
-*   **_/chunk (add/remove) (player)_** Display world chunk information such as chunk id, owner, players allowed, and access allowed. Optional arguments to add or remove players access
-*   **_/commands_** Opens gamemode command bar GUI with clickable menu
-*   **_/find (player), /f, /tpa_** Teleport to the closest Hero by default. Optional argument to teleport to a specific player. Costs one ender pearl for Heroes.
-*   **_/ghost, /spectate, /s_** Turns player into a ghost (spectator mode). Limited use for Heroes.
-*   **_/help (2), /h_** /help 2 Opens a text menu of all commands
-*   **_/home_** Teleports player to their bed's location. Costs one ender pearl for Heroes.
-*   **_/recipes_** Opens up the spell recipes GUI
-*   **_/spawn, /spawn (1/2/random)_** Teleports player to Spawn location. Costs one ender pearl for Heroes
-*   **_/store, /shop_** Opens up the store menu GUI
-
-* * *
-![](https://www.crawl-survival.com/assets/Up+to+30+Ghosts.png)
-
 Upon a Ghost killing a Hero: The Ghost will take the Heroes place and inventory. The slain Hero will become a Ghost.
-
 Ghosts spawn in spectator mode and can possess mobs by (Right) clicking on them. Use a creatures ability by Sneaking and (Left) clicking.
 
-### Ghost Commands
+- `/bl [<list/reset>]` Allows selected items or blocks to be blacklisted from the players inventory, making it easier to manage.
+- - Hold the item you wish to blacklist and type `/blocklist` Easy as that! To remove an item from the blocklist simply click on it!
+- - List blacklisted items with `/blocklist list`.
+- `/home` Teleports the players to their bed if it exists. Heroes must pay one ender pearl to use.
+- `/recipes` Lists craft able spell recipes for Heroes.
 
-*   **_/commands_** Opens gamemode command bar GUI with clickable menu
-*   **_/find (player), /f, /tpa_** Teleport to the closest Hero by default. Optional argument to teleport to a specific player.
-*   **_/help (2), /h_** /help 2 Opens a text menu of all commands
-*   **_/player, /play_** Turn player into a Hero (Survival Mode)
-*   **_/players_** Lists current Heroes
-*   **_/spawn (1/2/random)_** Teleports player to Spawn location. Costs one ender pearl for Heroes
-*   **_/store, /shop_** Opens up the store menu GUI. Click the top left corner to access **Artifacts**
-*   **_/view_** Toggles mob display model for ghosts. Often advised to enable this feature.
+### Ghost Commands
+If a Hero dies they will respawn as a Ghost in spectator mode that can possess mobs/monsters.
+Heroes must make it to The End to slay the Ender Dragon by collecting enough artifacts inside the dungeons.
+Heroes are able to purchase custom weapons and more at the shop using experience levels
+
+- `/artifacts` Opens up the Ghost artifacts in game GUI menu
+- `/view` Toggles the mob model display while disguised
 
 * * *
-![](https://www.crawl-survival.com/assets/Custom+artifacts+&+items.png)
 
-### Custom Items
+![](https://www.crawl-survival.com/assets/Custom+artifacts+&+items.png)
 
 Heroes can purchase 50+ custom items, kits, effects, and more in the store. Everything costs experience levels, so spend wisely.
 
 Ghosts can spawn monster bosses and upgrade them using artifacts that cost experience levels. The Artifacts menu can be found in /shop in the top left corner
 
 * * *
-![](https://www.crawl-survival.com/assets/Using+craftable+spells.png)
 
-### Craftable Spells
+![](https://www.crawl-survival.com/assets/Using+craftable+spells.png)
 
 Heroes can craft custom spells using raw materials bound with paper or books. Pull up the crafting recipes in game using the **/recipes** command. Once a spell is crafted, right click whilst in your hand to activate.
 
 * * *
+
 # Server Status
 
 ![](https://camo.githubusercontent.com/5032f4f77c432e23d79f3f3cc30d35cbaa7438a76efda32f89997e6a975fcc08/687474703a2f2f7374617475732e6d636c6976652e65752f4d696e656372616674253230312e31362e332532304a61766125323045646974696f6e2f706c61792e637261776c2d737572766976616c2e636f6d2f32353536352f62616e6e65722e706e67?raw=true)
 
 * * *
+
 # Server Updates
 <html>
 <ul>

--- a/pages/Home.md
+++ b/pages/Home.md
@@ -7,74 +7,69 @@ layout: wikiPage
 {% include_relative _Sidebar.md %}
 
 * * *
+
 ### How to Play _(Minecraft 1.16.4 Java Edition)_
 
-This server features a custom game mode similar to manhunt where players must clear out dungeons while fighting monsters controlled by other players. Each dungeon has progressive levels with custom loot and bosses.
+This server features a custom game mode similar to manhunt where players (_**Heroes**_) must clear out dungeons while fighting monsters controlled by other players (_**Ghosts**_). Each dungeon has progressive levels with custom loot and bosses.
 
-Players must play as either a Hero or Ghost. Ghosts play in spectator mode with the ability to control mobs/monsters. Ghosts must kill a Hero, in order to become a Hero. Ghosts can unlock artifacts as well as spawn and upgrade monsters using experience levels.
+Players must play as either a _**Hero**_ or _**Ghost**_. _**Ghosts**_ play in spectator mode with the ability to control mobs/monsters. _Ghosts_ must kill a Hero, in order to become a Hero. _Ghosts_ can unlock artifacts as well as spawn and upgrade monsters using experience levels.
 
-Heroes play in survival mode and must defeat dungeon levels in order to win. Heroes are able to purchase custom kits, items and enchantments using experience levels. Heroes are also able to craft custom spells. Learn more at the server wiki page.
+_**Heroes**_ play in survival mode and must defeat dungeon levels in order to win. _Heroes_ are able to purchase custom kits, items and enchantments using experience levels. Heroes are also able to craft custom spells. Learn more at the server wiki page.
 
 * * *
-![](https://www.crawl-survival.com/assets/Up+to+10+Heroes.png)
 
-If a player dies(or disconnects) as a Hero, they will become a Ghost, and their Hero slot (and inventory) is given to another player.
+### Gamemode Commands
 
-Heroes must make it to The End to slay the Ender Dragon. The player to retrieve the Egg will be rewarded champion
+- `/ghost` Respawn as a Ghost in spectator mode.
+- `/help` Opens up the Mine-Crawl in game GUI help menu
+- `/hero` Respawn as a Hero at spawn (or bed) in survival mode.
+- `/premium` Opens up in game premium GUI menu
+
+### Teleportation Commands
+
+- `/spawn` Teleports the player to spawn. Heroes have a cooldown.
+- `/find` Teleport to Heroes. Heroes can teleport to other Heroes but it will cost an ender pearl.
 
 ### Hero Commands
-
-*   **_/chest_** Opens up the player's ender chest. Costs one ender pearl for Heroes.
-*   **_/chunk (add/remove) (player)_** Display world chunk information such as chunk id, owner, players allowed, and access allowed. Optional arguments to add or remove players access
-*   **_/commands_** Opens gamemode command bar GUI with clickable menu
-*   **_/find (player), /f, /tpa_** Teleport to the closest Hero by default. Optional argument to teleport to a specific player. Costs one ender pearl for Heroes.
-*   **_/ghost, /spectate, /s_** Turns player into a ghost (spectator mode). Limited use for Heroes.
-*   **_/help (2), /h_** /help 2 Opens a text menu of all commands
-*   **_/home_** Teleports player to their bed's location. Costs one ender pearl for Heroes.
-*   **_/recipes_** Opens up the spell recipes GUI
-*   **_/spawn, /spawn (1/2/random)_** Teleports player to Spawn location. Costs one ender pearl for Heroes
-*   **_/store, /shop_** Opens up the store menu GUI
-
-* * *
-![](https://www.crawl-survival.com/assets/Up+to+30+Ghosts.png)
-
 Upon a Ghost killing a Hero: The Ghost will take the Heroes place and inventory. The slain Hero will become a Ghost.
-
 Ghosts spawn in spectator mode and can possess mobs by (Right) clicking on them. Use a creatures ability by Sneaking and (Left) clicking.
 
-### Ghost Commands
+- `/bl [<list/reset>]` Allows selected items or blocks to be blacklisted from the players inventory, making it easier to manage.
+- - Hold the item you wish to blacklist and type `/blocklist` Easy as that! To remove an item from the blocklist simply click on it!
+- - List blacklisted items with `/blocklist list`.
+- `/home` Teleports the players to their bed if it exists. Heroes must pay one ender pearl to use.
+- `/recipes` Lists craft able spell recipes for Heroes.
 
-*   **_/commands_** Opens gamemode command bar GUI with clickable menu
-*   **_/find (player), /f, /tpa_** Teleport to the closest Hero by default. Optional argument to teleport to a specific player.
-*   **_/help (2), /h_** /help 2 Opens a text menu of all commands
-*   **_/player, /play_** Turn player into a Hero (Survival Mode)
-*   **_/players_** Lists current Heroes
-*   **_/spawn (1/2/random)_** Teleports player to Spawn location. Costs one ender pearl for Heroes
-*   **_/store, /shop_** Opens up the store menu GUI. Click the top left corner to access **Artifacts**
-*   **_/view_** Toggles mob display model for ghosts. Often advised to enable this feature.
+### Ghost Commands
+If a Hero dies they will respawn as a Ghost in spectator mode that can possess mobs/monsters.
+Heroes must make it to The End to slay the Ender Dragon by collecting enough artifacts inside the dungeons.
+Heroes are able to purchase custom weapons and more at the shop using experience levels
+
+- `/artifacts` Opens up the Ghost artifacts in game GUI menu
+- `/view` Toggles the mob model display while disguised
 
 * * *
-![](https://www.crawl-survival.com/assets/Custom+artifacts+&+items.png)
 
-### Custom Items
+![](https://www.crawl-survival.com/assets/Custom+artifacts+&+items.png)
 
 Heroes can purchase 50+ custom items, kits, effects, and more in the store. Everything costs experience levels, so spend wisely.
 
 Ghosts can spawn monster bosses and upgrade them using artifacts that cost experience levels. The Artifacts menu can be found in /shop in the top left corner
 
 * * *
-![](https://www.crawl-survival.com/assets/Using+craftable+spells.png)
 
-### Craftable Spells
+![](https://www.crawl-survival.com/assets/Using+craftable+spells.png)
 
 Heroes can craft custom spells using raw materials bound with paper or books. Pull up the crafting recipes in game using the **/recipes** command. Once a spell is crafted, right click whilst in your hand to activate.
 
 * * *
+
 # Server Status
 
 ![](https://camo.githubusercontent.com/5032f4f77c432e23d79f3f3cc30d35cbaa7438a76efda32f89997e6a975fcc08/687474703a2f2f7374617475732e6d636c6976652e65752f4d696e656372616674253230312e31362e332532304a61766125323045646974696f6e2f706c61792e637261776c2d737572766976616c2e636f6d2f32353536352f62616e6e65722e706e67?raw=true)
 
 * * *
+
 # Server Updates
 <html>
 <ul>


### PR DESCRIPTION
### Patch 4.6-7
- Hero shop located at spawn has been updated and all items should be working properly
- Bone, Poison, Ghoul, and Feathershrimp charms have been updated and must be equip to the offhand slot
- Several premium weapon abilities have been updated including but not limited to:
- - Powerul weapons forged in the nether that strike lightning at opponents
- - Powerul weapons that take out your foes using explosions from afar
- - Much more
