### PR TITLE
Update 5.0

### DIFF
--- a/_posts/2021-01-25-Update-5.0.md
+++ b/_posts/2021-01-25-Update-5.0.md
@@ -1,0 +1,6 @@
+- Function to enter the end needs to be enabled for Heroes who have 5 artifacts in their inventory. **Coming soon!** 
+  - Heroes with five Crawl artifacts in their inventory when the enter the portal: Will be taken to fight the dragon!
+  - Defeating the dragon will knight you as a champion and you will have control over the dragon next time it faces another Hero!
+- Adventure mode added therefore heroes and ghosts can't break blocks EXCEPT certain materials! Cobblestone, doors, beds, torches, etc.
+- Creeper explosions have been reworked to void block damage
+- More adjustments coming soon in patch 5.1


### PR DESCRIPTION
- Function to enter the end needs to be enabled for Heroes who have 5 artifacts in their inventory. **Coming soon!** 
  - Heroes with five Crawl artifacts in their inventory when the enter the portal: Will be taken to fight the dragon!
  - Defeating the dragon will knight you as a champion and you will have control over the dragon next time it faces another Hero!
- Adventure mode added therefore heroes and ghosts can't break blocks EXCEPT certain materials! Cobblestone, doors, beds, torches, etc.
- Creeper explosions have been reworked to void block damage
- More adjustments coming soon in patch 5.1